### PR TITLE
Introduced command to retrieve PowerState and cleanup

### DIFF
--- a/jvc_projector/__init__.py
+++ b/jvc_projector/__init__.py
@@ -1,5 +1,7 @@
 import socket
 from enum import Enum
+from time import sleep
+
 
 class Commands(Enum):
     # power commands
@@ -58,11 +60,13 @@ class JVCProjector:
     def __init__(self, host, port = 20554):
         self.host = host
         self.port = port
+        self.delay = 0.6
 
     def _send_command(self, operation, ack=None):
         JVC_GREETING = b'PJ_OK'
         JVC_REQ = b'PJREQ'
         JVC_ACK = b'PJACK'
+        result = False
 
         jvc_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         jvc_sock.connect((self.host, self.port)) # connect to projector
@@ -94,10 +98,13 @@ class JVCProjector:
 
             if ACK == ack:
                 message = jvc_sock.recv(1024)
-                jvc_sock.close()
-                return message
+                result = message
+
         jvc_sock.close()
 
+        sleep(self.delay)
+
+        return result
 
     def power_on(self):
         self._send_command(Commands.power_on.value)

--- a/jvc_projector/__init__.py
+++ b/jvc_projector/__init__.py
@@ -71,7 +71,10 @@ class JVCProjector:
         result = False
 
         jvc_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        jvc_sock.connect((self.host, self.port)) # connect to projector
+        try:
+            jvc_sock.connect((self.host, self.port)) # connect to projector
+        except:
+            return "unknown"
 
         # 3 step handshake:
         # Projector sends PJ_OK, client sends PJREQ, projector replies with PJACK
@@ -126,6 +129,8 @@ class JVCProjector:
         for x in PowerStates:
             if x.value == message:
                 return x.name
+
+        return "unknown"
 
     def is_on(self):
         on = [PowerStates.lamp_on.value, PowerStates.reserved.value]

--- a/jvc_projector/__init__.py
+++ b/jvc_projector/__init__.py
@@ -119,12 +119,13 @@ class JVCProjector:
             self._send_command(Commands[command_string].value)
             return True
 
+    def power_state(self):
+        message = self._send_command(Commands.power_status.value, ack=ACKs.power_ack.value)
+        for x in PowerStates:
+            if x.value == message:
+                return x.name
+
     def is_on(self):
-        message = self._send_command(Commands.power_status.value, ack = ACKs.power_ack.value)
-        if message == PowerStates.lamp_on.value or message == PowerStates.reserved.value:
-            return True
-        elif message == PowerStates.standby.value or message == PowerStates.cooling.value or message == PowerStates.emergency.value:
-            return False
-
-
+        on = [PowerStates.lamp_on.value, PowerStates.reserved.value]
+        return self.power_state() in on
 

--- a/jvc_projector/__init__.py
+++ b/jvc_projector/__init__.py
@@ -60,9 +60,10 @@ class ACKs(Enum):
 class JVCProjector:
     """JVC Projector Control"""
 
-    def __init__(self, host, port=20554, delay_ms=600):
+    def __init__(self, host, port=20554, delay_ms=600, connect_timeout=60):
         self.host = host
         self.port = port
+        self.connect_timeout = connect_timeout
         self.delay = datetime.timedelta(microseconds=(delay_ms * 1000))
         self.last_command_time = datetime.datetime.now() - datetime.timedelta(seconds=10)
 
@@ -86,6 +87,7 @@ class JVCProjector:
         self.throttle()
 
         jvc_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        jvc_sock.settimeout(self.connect_timeout)
         jvc_sock.connect((self.host, self.port)) # connect to projector
 
         # 3 step handshake:

--- a/jvc_projector/__init__.py
+++ b/jvc_projector/__init__.py
@@ -5,7 +5,7 @@ from time import sleep
 
 class Commands(Enum):
     # power commands
-    power_on  = b"\x21\x89\x01\x50\x57\x31\x0A"
+    power_on = b"\x21\x89\x01\x50\x57\x31\x0A"
     power_off = b"\x21\x89\x01\x50\x57\x30\x0A"
 
     # lens memory commands
@@ -37,6 +37,7 @@ class Commands(Enum):
     pm_user6 = b"\x21\x89\x01\x50\x4D\x50\x4D\x31\x31\x0A"
     pm_hlg = b"\x21\x89\x01\x50\x4D\x50\x4D\x31\x34\x0A"
 
+
 class PowerStates(Enum):
     standby   = b"\x40\x89\x01\x50\x57\x30\x0A"
     cooling   = b"\x40\x89\x01\x50\x57\x32\x0A"
@@ -49,6 +50,7 @@ class PowerStates(Enum):
     lamp_on  = b"\x40\x89\x01\x50\x57\x31\x0A"
     reserved = b"\x40\x89\x01\x50\x57\x33\x0A"
 
+
 class ACKs(Enum):
     power_ack = b"\x06\x89\x01\x50\x57\x0A"
     input_ack = b"\x06\x89\x01\x49\x50\x0A"
@@ -57,7 +59,7 @@ class ACKs(Enum):
 class JVCProjector:
     """JVC Projector Control"""
 
-    def __init__(self, host, port = 20554):
+    def __init__(self, host, port=20554):
         self.host = host
         self.port = port
         self.delay = 0.6

--- a/jvc_projector/__init__.py
+++ b/jvc_projector/__init__.py
@@ -77,7 +77,6 @@ class JVCProjector:
 
         return
 
-
     def _send_command(self, operation, ack=None):
         JVC_GREETING = b'PJ_OK'
         JVC_REQ = b'PJREQ'
@@ -87,10 +86,7 @@ class JVCProjector:
         self.throttle()
 
         jvc_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            jvc_sock.connect((self.host, self.port)) # connect to projector
-        except:
-            return "unknown"
+        jvc_sock.connect((self.host, self.port)) # connect to projector
 
         # 3 step handshake:
         # Projector sends PJ_OK, client sends PJREQ, projector replies with PJACK
@@ -142,11 +138,7 @@ class JVCProjector:
 
     def power_state(self):
         message = self._send_command(Commands.power_status.value, ack=ACKs.power_ack.value)
-        for x in PowerStates:
-            if x.value == message:
-                return x.name
-
-        return "unknown"
+        return PowerStates(message).name
 
     def is_on(self):
         on = [PowerStates.lamp_on.value, PowerStates.reserved.value]


### PR DESCRIPTION
It introduces a new command to retrieve the PowerState, which is usefull within Home Assistant.

Further I introduced a (global) delay for successive commands (which could be a bit better as it now waits after the command instead of checking if it had ran in the last X seconds, maybe I'll ammend the PR). This should (partially) fix issue #3. 

I also did a little cleanup (removed double sock.close(), and some code cleanup)