### PR TITLE
Fix issue where is_on() is returning False for all projector states.

### DIFF
--- a/jvc_projector/__init__.py
+++ b/jvc_projector/__init__.py
@@ -175,9 +175,9 @@ class JVCProjector:
 
     def power_state(self):
         message = self._send_command(Commands.power_status.value, ack=ACKs.power_ack.value)
-        return PowerStates(message).name
+        return PowerStates(message)
 
     def is_on(self):
-        on = [PowerStates.lamp_on.name, PowerStates.reserved.name]
+        on = [PowerStates.lamp_on, PowerStates.reserved]
         return self.power_state() in on
 


### PR DESCRIPTION
With python 3.8 the homebridge-jvc-projector v1.2.4 homebridge plugin would always show my projector accessory as being powered off state. I patched the jvc_projector package on my homebridge deployment with these changes to get it working correctly.