### PR TITLE
Add support for setting Network Password

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,21 @@ pip install -e git+https://github.com/bezmi/jvc_projector.git#egg=jvc-projector-
 # Usage
 For usage with homeassistant, [see here](https://github.com/bezmi/hass_custom_components).
 
-Here is am example for using this module standalone:
+Here is an example for using this module standalone:
 ``` python
 >>> from jvc_projector import JVCProjector
 
  # replace with your projector's local IP
 >>> host = "192.168.1.12"
 
+ # replace with your projector's network password (if applicable)
+>>> password = "MYPASSWORD"
+
 # initialise
 >>> projector = JVCProjector(host)
+
+# initialise (alternate, with network password)
+>>> projector = JVCProjector(host, password)
 
 # power on, power off
 >>> projector.power_on()
@@ -65,6 +71,7 @@ projector and I will add it to the list below.
 ## Confirmed Models
 * DLA-X5900
 * NX5
+* NZ8/RS3100
 
 # Bugs
 The main issue one might face is receiving ConnectionRefusedError when making a

--- a/jvc_projector/__init__.py
+++ b/jvc_projector/__init__.py
@@ -95,12 +95,13 @@ class ACKs(Enum):
 class JVCProjector:
     """JVC Projector Control"""
 
-    def __init__(self, host, port=20554, delay_ms=600, connect_timeout=60):
+    def __init__(self, host, password = None, port=20554, delay_ms=600, connect_timeout=60):
         self.host = host
         self.port = port
         self.connect_timeout = connect_timeout
         self.delay = datetime.timedelta(microseconds=(delay_ms * 1000))
         self.last_command_time = datetime.datetime.now() - datetime.timedelta(seconds=10)
+        self.password = password
 
     def throttle(self):
         if self.delay == 0:
@@ -115,7 +116,17 @@ class JVCProjector:
 
     def _send_command(self, operation, ack=None):
         JVC_GREETING = b'PJ_OK'
-        JVC_REQ = b'PJREQ'
+        if self.password != None:
+            if len(self.password) == 10:
+                JVC_REQ = b'PJREQ_' + bytes(self.password, 'ascii')
+            elif len(self.password) == 9:
+                JVC_REQ = b'PJREQ_' + bytes(self.password, 'ascii') + b'\x00'
+            elif len(self.password) == 8:
+                JVC_REQ = b'PJREQ_' + bytes(self.password, 'ascii') + b'\x00\x00'
+            else:
+                raise Exception("Specified network password invalid (too long/short)")
+        else:
+            JVC_REQ = b'PJREQ'
         JVC_ACK = b'PJACK'
         result = False
 


### PR DESCRIPTION
With the release of the latest projectors (NZ series and their respective RS variants) JVC has decided to implement a "Network Password" which must be sent during the 3-way handshake in order to interact with the projector. The network password _must_ be between 8 and 10 characters (projector requirement), and it cannot be left blank. A blank or incorrect password will result in a PJNAK response from the Projector, which will prevent any further commands being accepted on the socket. 

The format for sending this network password is by sending PJREQ_<NetworkPassword>. If the password is less than 10 characters, it has to be padded to 10 characters with additional null characters. The proposed change here would evaluate the password being passed, if empty it will simply send a PJREQ request like it has in the past. If it is set, it will evaluate for validity (8-10 characters only), pad as necessary, and send the request _with_ network password to the projector during the handshake. 

A separate PR will be forthcoming to add support for setting the password in the Home Assistant component, but this change was tested and confirmed working with standalone usage. 

Attached is the JVC 2021 Model LAN connection specification document for reference.
[ILAFPJ2021_LANconnection_spec_EN.pdf](https://github.com/bezmi/jvc_projector/files/8427311/ILAFPJ2021_LANconnection_spec_EN.pdf)

